### PR TITLE
Update ref for RDF Term

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -229,7 +229,7 @@
               </tbody>
             </table>
           </div>
-          <p>A 'binding' is a pair (<a data-cite="SPARQL12-QUERY#defn_QueryVariable">variable</a>, <a data-cite="SPARQL12-QUERY#defn_RDFTerm">RDF term</a>). In this
+          <p>A 'binding' is a pair (<a data-cite="SPARQL12-QUERY#defn_QueryVariable">variable</a>, <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>). In this
           result set, there are three variables: <code>x</code>, <code>y</code>, and <code>z</code> (shown as column headers). Each solution is shown as one row in the body of the table. Here, there
           is a single solution, in which variable <code>x</code> is bound to <code>"Alice"</code>, variable <code>y</code> is bound to <code>&lt;http://example/a&gt;</code>, and variable
           <code>z</code> is not bound to an RDF term. Variables are not required to be bound in a solution.</p>


### PR DESCRIPTION
Fix broken reference.
RDF Term is now defined in RDF Concepts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/pull/22.html" title="Last updated on May 3, 2023, 10:58 AM UTC (ee6f029)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/22/329ea83...ee6f029.html" title="Last updated on May 3, 2023, 10:58 AM UTC (ee6f029)">Diff</a>