### PR TITLE
Update refs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -451,7 +451,7 @@ span.cancast:hover { background-color: #ffa;
         </section>
         <section id="prelims">
           <h4>Preliminary Definitions</h4>
-          <p>This document uses the same <a data-cite="SPARQL12-QUERY#sparqlBasicTerms">definitions</a> as the
+          <p>This document uses the same <a data-cite="SPARQL12-QUERY#initDefinitions">definitions</a> as the
             [[[SPARQL12-QUERY]]] specification. Important terms are recaptured below for clarity. In the case of any differences, the SPARQL Query Language definitions are the normative ones.</p>
           <p>The term <em>I</em> denotes the set of all IRIs, <em>RDF-L</em> the set of all <a data-cite="RDF12-CONCEPTS#dfn-literal">RDF Literals</a>,
           and <em>RDF-B</em> the set of all <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a> in RDF graphs.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -808,7 +808,7 @@ ex:d rdf:_1 ex:a .</pre>
             </tbody>
           </table>
         </div>
-        <p>since <code>ex:a ex:b ex:c</code> RDF entails <code>ex:b a rdf:Property</code> (see also the <a data-cite="RDF12-SEMANTICS#dfn-rdfD1">RDF entailment rule</a> <em>rdfD1</em>). Further, the axiomatic triples give possible solutions such as</p>
+        <p>since <code>ex:a ex:b ex:c</code> RDF entails <code>ex:b a rdf:Property</code> (see also the <a data-cite="RDF12-SEMANTICS#dfn-rdfd1">RDF entailment rule</a> <em>rdfD1</em>). Further, the axiomatic triples give possible solutions such as</p>
         <div class="result">
           <span class="doc-ref" id="table4"></span>
           <table class="resultTable">


### PR DESCRIPTION
Fix broken references
* SPARQL basic terms section no longer exists - move to teh overall section
* Link into Semantics broken.

This resolves #21.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/pull/23.html" title="Last updated on May 3, 2023, 5:36 PM UTC (b025269)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/23/018e4a2...b025269.html" title="Last updated on May 3, 2023, 5:36 PM UTC (b025269)">Diff</a>