### PR TITLE
Shows all related documents in `details`.

### DIFF
--- a/spec/common/fixup.js
+++ b/spec/common/fixup.js
@@ -46,7 +46,7 @@ function unComment(utils, content) {
 // If content is a self-citation, replace it with the document name
 function noSelfCite(utils, content) {
   if (content.toUpperCase() === `[[[${respecConfig.shortName}]]]`.toUpperCase()) {
-    return respecConfig.title + '(this document)';
+    return respecConfig.title + ' (this document)';
   } else {
     return content;
   }

--- a/spec/common/local-biblio.js
+++ b/spec/common/local-biblio.js
@@ -1,14 +1,4 @@
 var localBibliography = {
-  CBD: {
-    "title": "CBD - Concise Bounded Description",
-    "href": "https://www.w3.org/Submission/CBD/",
-    "authors": [
-      "Patrick Stickler, Nokia"
-    ],
-    "rawDate": "2005-06-03",
-    "publisher": "W3C",
-    "status": "W3C Member Submission"
-  },
   ISO24707: {
     id: "ISO24707",
     title: "Information technology — Common Logic (CL) — A framework for a family of logic-based languages",

--- a/spec/common/rdf-related.html
+++ b/spec/common/rdf-related.html
@@ -3,7 +3,7 @@
 <details>
 <summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>

--- a/spec/common/rdf-related.html
+++ b/spec/common/rdf-related.html
@@ -1,5 +1,5 @@
 <h4>Set of Documents</h4>
-<p>This document is one of eleven RDF 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<p>This document is one of ten RDF 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
 <details>
 <summary>List of documents</summary>
 
@@ -14,7 +14,6 @@
   <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
-  <li data-transform="noSelfCite">[[[RDF12-UCR]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 </details>

--- a/spec/common/rdf-related.html
+++ b/spec/common/rdf-related.html
@@ -1,5 +1,7 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of eleven RDF 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
 <p>RDF 1.2 Recommendations:</p>
 <ol>
@@ -12,5 +14,7 @@
   <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-UCR]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
+</details>

--- a/spec/common/related.html
+++ b/spec/common/related.html
@@ -3,7 +3,7 @@
 <details>
 <summary>List of documents</summary>
 
-<p>RDF 1.2 Recommendations:</p>
+<p>RDF 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[RDF12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-CONCEPTS]]]</li>
@@ -17,7 +17,7 @@
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>

--- a/spec/common/related.html
+++ b/spec/common/related.html
@@ -1,5 +1,7 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
 <p>RDF 1.2 Recommendations:</p>
 <ol>
@@ -12,6 +14,7 @@
   <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
+  <li data-transform="noSelfCite">[[[RDF12-UCR]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 
@@ -30,3 +33,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>

--- a/spec/common/related.html
+++ b/spec/common/related.html
@@ -1,5 +1,5 @@
 <h4>Set of Documents</h4>
-<p>This document is one of eleven RDF 1.2 and twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
 <details>
 <summary>List of documents</summary>
 
@@ -14,7 +14,6 @@
   <li data-transform="noSelfCite">[[[RDF12-SEMANTICS]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TRIG]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-TURTLE]]]</li>
-  <li data-transform="noSelfCite">[[[RDF12-UCR]]]</li>
   <li data-transform="noSelfCite">[[[RDF12-XML]]]</li>
 </ol>
 

--- a/spec/common/related.html
+++ b/spec/common/related.html
@@ -1,5 +1,5 @@
 <h4>Set of Documents</h4>
-<p>This document is one of ten RDF 1.2 and twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<p>This document is one of eleven RDF 1.2 and twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
 <details>
 <summary>List of documents</summary>
 

--- a/spec/common/sparql-related.html
+++ b/spec/common/sparql-related.html
@@ -3,7 +3,7 @@
 <details>
 <summary>List of documents</summary>
 
-<p>SPARQL 1.2 Recommendations:</p>
+<p>SPARQL 1.2 Documents:</p>
 <ol>
   <li data-transform="noSelfCite">[[[SPARQL12-NEW]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-CONCEPTS]]]</li>

--- a/spec/common/sparql-related.html
+++ b/spec/common/sparql-related.html
@@ -1,5 +1,7 @@
 <h4>Set of Documents</h4>
-<p>This document is one of twelve SPARQL 1.2 Recommendations produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>:</p>
+<p>This document is one of twelve SPARQL 1.2 documents produced by the <a href="https://www.w3.org/groups/wg/rdf-star">RDF-star Working Group</a>.</p>
+<details>
+<summary>List of documents</summary>
 
 <p>SPARQL 1.2 Recommendations:</p>
 <ol>
@@ -16,3 +18,4 @@
   <li data-transform="noSelfCite">[[[SPARQL12-PROTOCOL]]]</li>
   <li data-transform="noSelfCite">[[[SPARQL12-GRAPH-STORE-PROTOCOL]]]</li>
 </ol>
+</details>

--- a/spec/index.html
+++ b/spec/index.html
@@ -361,7 +361,7 @@ span.cancast:hover { background-color: #ffa;
         update of specifications for format and errata.
       </p>
 
-      <section data-include="common/sparql-related.html"></section>
+      <section data-include="common/related.html"></section>
     </section>
     
 <!-- BODY -->


### PR DESCRIPTION
(Note, build will complain that it is out of sync with the rdf-common repository, until we make it a global change).

See rendered version [here](https://raw.githack.com/w3c/sparql-entailment/related-details/spec/index.html).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/pull/31.html" title="Last updated on Jun 15, 2023, 9:06 PM UTC (ff62487)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/31/9c8cc3f...ff62487.html" title="Last updated on Jun 15, 2023, 9:06 PM UTC (ff62487)">Diff</a>