### PR TITLE
GitHub actions: replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   main:
     name: Echidna Auto-publish WD
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
[GitHub will no longer support the Ubuntu 20.04 runner image starting from April 1, 2025](https://github.com/actions/runner-images/issues/11101). That PR updates the actions to use ubuntu-latest instead