### PR TITLE
fix wrong entailment rule in RDF entailment example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -516,7 +516,7 @@ span.cancast:hover { background-color: #ffa;
         <p>Consider, for example, the following query:</p>
         <pre class="query">SELECT ?prop WHERE { ?prop rdf:type rdf:Property }</pre>
         <p>Under simple entailment the query has an empty answer when querying the above graph. Under RDF entailment, the
-          RDF rule <a data-cite="RDF12-SEMANTICS#dfn-rdfd1">rdfD1</a> be used on (5) to derive the triple <code>ex:publishes rdf:type rdf:Property</code> which means that
+          RDF rule <a data-cite="RDF12-SEMANTICS#dfn-rdfd2">rdfD2</a> be used on (5) to derive the triple <code>ex:publishes rdf:type rdf:Property</code> which means that
         <code>ex:publishes</code> is a valid binding for <code>?prop</code> and will be returned as an answer for the query from a system that uses RDF entailment.</p>
         <p>The following query asks for a list of all publications:</p>
         <pre class="query">SELECT ?pub WHERE { ?pub rdf:type ex:Publication }</pre>


### PR DESCRIPTION
Fixes #40


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/pull/41.html" title="Last updated on Aug 5, 2025, 11:30 AM UTC (30e7b9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-entailment/41/1aa6b3d...30e7b9b.html" title="Last updated on Aug 5, 2025, 11:30 AM UTC (30e7b9b)">Diff</a>